### PR TITLE
Fix of ValidationTokenParser - stop on the last line of the class file.

### DIFF
--- a/Form/ValidationTokenParser.php
+++ b/Form/ValidationTokenParser.php
@@ -219,17 +219,11 @@ class ValidationTokenParser implements ValidationParser
             return '';
         }
 
-        $file->seek($lineNumber - 2);
-        $contents = '<?php ';
+        $file->seek($lineNumber - 1);
+        $contents = '<?php ' . $file->current();
 
-        while ($line = $file->fgets()) {
-            $contents .= $line;
-
-            if ($lineNumber === $class->getEndLine()) {
-                break;
-            }
-
-            $lineNumber++;
+        while ($lineNumber++ < $class->getEndLine()) {
+            $contents .= $file->fgets();
         }
 
         return $contents;

--- a/Form/ValidationTokenParser.php
+++ b/Form/ValidationTokenParser.php
@@ -225,11 +225,11 @@ class ValidationTokenParser implements ValidationParser
         while ($line = $file->fgets()) {
             $contents .= $line;
 
+            $lineNumber++;
+
             if ($lineNumber === $class->getEndLine()) {
                 break;
             }
-
-            $lineNumber++;
         }
 
         return $contents;

--- a/Form/ValidationTokenParser.php
+++ b/Form/ValidationTokenParser.php
@@ -219,17 +219,17 @@ class ValidationTokenParser implements ValidationParser
             return '';
         }
 
-        $file->seek($lineNumber - 1);
+        $file->seek($lineNumber - 2);
         $contents = '<?php ';
 
         while ($line = $file->fgets()) {
             $contents .= $line;
 
-            $lineNumber++;
-
             if ($lineNumber === $class->getEndLine()) {
                 break;
             }
+
+            $lineNumber++;
         }
 
         return $contents;


### PR DESCRIPTION
While cycle tried to read non-existing line from the file if there was newline missing at the end of the file.