### PR TITLE
Form translations - try to avoid fallback

### DIFF
--- a/Resources/views/formTranslator.html.twig
+++ b/Resources/views/formTranslator.html.twig
@@ -14,17 +14,17 @@
     {% endif -%}
 {% endmacro %}
 
-{% macro translate_recursive(id, translationDomain = null, currentPath = null, includeFallback = false) -%}
+{% macro translate_recursive(id, translationDomain = null, currentPath = null, preferFallback = false) -%}
     {% import _self as self -%}
 
     {% set currentId = currentPath is same as(null) ? id : currentPath|join('.') -%}
     {% set currentPath = currentPath ?? id|split('.') -%}
 
-    {% if is_translated(currentId, translationDomain, null, includeFallback) -%}
+    {% if is_translated(currentId, translationDomain, null, preferFallback) -%}
         {{ currentId|trans({}, translationDomain) -}}
     {% elseif currentPath|length > 1 -%}
         {{ self.translate_recursive(id, translationDomain, currentPath|slice(1)) -}}
-    {% elseif not useFallback -%}
+    {% elseif not preferFallback -%}
         {{ self.translate_recursive(id, translationDomain, null, true) -}}
     {% else -%}
         {{ currentId -}}

--- a/Resources/views/formTranslator.html.twig
+++ b/Resources/views/formTranslator.html.twig
@@ -24,8 +24,8 @@
         {{ currentId|trans({}, translationDomain) -}}
     {% elseif currentPath|length > 1 -%}
         {{ self.translate_recursive(id, translationDomain, currentPath|slice(1)) -}}
-    {% elseif not useFallback %}
-        {{ self.translate_recursive(id, translationDomain, null, true) }}
+    {% elseif not useFallback -%}
+        {{ self.translate_recursive(id, translationDomain, null, true) -}}
     {% else -%}
         {{ currentId -}}
     {% endif -%}

--- a/Resources/views/formTranslator.html.twig
+++ b/Resources/views/formTranslator.html.twig
@@ -14,16 +14,18 @@
     {% endif -%}
 {% endmacro %}
 
-{% macro translate_recursive(id, translationDomain = null, currentPath = null) -%}
+{% macro translate_recursive(id, translationDomain = null, currentPath = null, includeFallback = false) -%}
     {% import _self as self -%}
 
     {% set currentId = currentPath is same as(null) ? id : currentPath|join('.') -%}
     {% set currentPath = currentPath ?? id|split('.') -%}
 
-    {% if is_translated(currentId, translationDomain) -%}
+    {% if is_translated(currentId, translationDomain, null, includeFallback) -%}
         {{ currentId|trans({}, translationDomain) -}}
     {% elseif currentPath|length > 1 -%}
         {{ self.translate_recursive(id, translationDomain, currentPath|slice(1)) -}}
+    {% elseif not useFallback %}
+        {{ self.translate_recursive(id, translationDomain, null, true) }}
     {% else -%}
         {{ currentId -}}
     {% endif -%}

--- a/Templating/WebExtension.php
+++ b/Templating/WebExtension.php
@@ -230,14 +230,16 @@ class WebExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInt
         return $scripts;
     }
 
-    public function isTranslated(string $id, string $domain = null, string $locale = null): bool
+    public function isTranslated(string $id, string $domain = null, string $locale = null, bool $includeFallback = true): bool
     {
         if ($domain === null) {
             $domain = 'messages';
         }
 
+        $methodName = $includeFallback ? 'has' : 'defines';
+
         return $this->translator instanceof TranslatorBagInterface
-            && $this->translator->getCatalogue($locale)->has($id, $domain)
+            && $this->translator->getCatalogue($locale)->$methodName($id, $domain)
             && $this->translator->getCatalogue($locale)->get($id, $domain) !== false;
     }
 


### PR DESCRIPTION
Use less specific path for translation instead of using fallback when translation for given locale doesn't exist.